### PR TITLE
add `receiver.New`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.23.0
 	github.com/bits-and-blooms/bitset v1.11.0
 	github.com/cloudevents/sdk-go/v2 v2.14.0
+	github.com/coreos/go-oidc/v3 v3.7.0
 	github.com/google/go-cmp v0.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.1
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8

--- a/pkg/events/receiver/receiver.go
+++ b/pkg/events/receiver/receiver.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2023 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package receiver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
+	"github.com/coreos/go-oidc/v3/oidc"
+)
+
+// Handler is a function that handles a CloudEvent.
+type Handler func(ctx context.Context, event cloudevents.Event) error
+
+// New returns a new Handler that verifies the Event was sent by Chainguard,
+// intended for the specified Group, then invokes the provided Handler.
+//
+// TODO(jason): Accept options for configuring the issuer and accepted event types.
+func New(ctx context.Context, issuer, group string, fn Handler) (Handler, error) {
+	// Construct a verifier that ensures tokens are issued by the Chainguard
+	// issuer we expect and are intended for a customer webhook.
+	provider, err := oidc.NewProvider(ctx, issuer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create provider: %w", err)
+	}
+	verifier := provider.Verifier(&oidc.Config{ClientID: "customer"})
+
+	return func(ctx context.Context, event cloudevents.Event) error {
+		// We expect Chainguard webhooks to pass an Authorization header.
+		auth := strings.TrimPrefix(cehttp.RequestDataFromContext(ctx).Header.Get("Authorization"), "Bearer ")
+		if auth == "" {
+			return cloudevents.NewHTTPResult(http.StatusUnauthorized, "Unauthorized")
+		}
+
+		// Verify that the token is well-formed, and in fact intended for us!
+		if tok, err := verifier.Verify(ctx, auth); err != nil {
+			return cloudevents.NewHTTPResult(http.StatusForbidden, "unable to verify token: %w", err)
+		} else if !strings.HasPrefix(tok.Subject, "webhook:") {
+			return cloudevents.NewHTTPResult(http.StatusForbidden, "subject should be from the Chainguard webhook component, got: %s", tok.Subject)
+		} else if got := strings.TrimPrefix(tok.Subject, "webhook:"); got != group {
+			return cloudevents.NewHTTPResult(http.StatusForbidden, "this token is intended for %s, wanted one for %s", got, group)
+		}
+		return fn(ctx, event)
+	}, nil
+}


### PR DESCRIPTION
This is copied from https://github.com/chainguard-dev/enforce-events/blob/main/pkg/receiver/receiver.go with the change that `New` returns an error instead of `log.Fatal`.