### PR TITLE
Add verification logic for webhook token custom claims.

### DIFF
--- a/events/webhook.go
+++ b/events/webhook.go
@@ -1,0 +1,14 @@
+/*
+Copyright 2023 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package events
+
+// WebhookCustomClaims holds the custom claims embedded in the webhook's
+// OIDC authorization token.
+type WebhookCustomClaims struct {
+	Webhook struct {
+		Digest string `json:"digest"`
+	} `json:"webhook"`
+}


### PR DESCRIPTION
This change adds logic to extract and validate the custom message-digest claims that we are starting to embed in the tokens accompanying our webhook requests to further improve the security properties of Chainguard webhooks.

Now these authorization tokens effective sign the message payload they are intended to accompany, which makes it even less practical to spoof events as coming from Chainguard.