### PR TITLE
Add ability to return nil responses from mock ping

### DIFF
--- a/proto/platform/ping/v1/test/ping.go
+++ b/proto/platform/ping/v1/test/ping.go
@@ -46,7 +46,7 @@ type Ping struct {
 
 func (m MockPingServiceClient) Ping(_ context.Context, _ *ping.PingRequest, _ ...grpc.CallOption) (*ping.Response, error) {
 	if m.OnPing.Given == nil {
-		return nil, fmt.Errorf("mock not found for %v", m.OnPing.Given)
+		return nil, fmt.Errorf("OnPing.Given defined to be %v", m.OnPing.Given)
 	}
 	return &ping.Response{}, nil
 }

--- a/proto/platform/ping/v1/test/ping.go
+++ b/proto/platform/ping/v1/test/ping.go
@@ -7,6 +7,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/grpc"
 
@@ -44,5 +45,8 @@ type Ping struct {
 }
 
 func (m MockPingServiceClient) Ping(_ context.Context, _ *ping.PingRequest, _ ...grpc.CallOption) (*ping.Response, error) {
+	if m.OnPing.Given == nil {
+		return nil, fmt.Errorf("mock not found for %v", m.OnPing.Given)
+	}
 	return &ping.Response{}, nil
 }


### PR DESCRIPTION
Part of https://github.com/chainguard-dev/mono/issues/15170 and https://github.com/chainguard-dev/mono/pull/15386.