### PR TITLE
Accept `refresh_token` in http callback

### DIFF
--- a/auth/login/options.go
+++ b/auth/login/options.go
@@ -48,6 +48,9 @@ type config struct {
 	// IncludeUpstreamToken tells the issuer to include the encrypted upstream token
 	// in the Chainguard token
 	IncludeUpstreamToken bool
+
+	// CreateRefreshToken tells the issuer to create a refresh token
+	CreateRefreshToken bool
 }
 
 const defaultIssuer = `https://issuer.enforce.dev`
@@ -168,5 +171,11 @@ func WithSkipRegistration() Option {
 func WithIncludeUpstreamToken() Option {
 	return func(c *config) {
 		c.IncludeUpstreamToken = true
+	}
+}
+
+func WithCreateRefreshToken() Option {
+	return func(c *config) {
+		c.CreateRefreshToken = true
 	}
 }

--- a/auth/login/server.go
+++ b/auth/login/server.go
@@ -23,6 +23,8 @@ type server struct {
 
 	token chan string
 
+	refreshToken string
+
 	l net.Listener
 }
 
@@ -65,6 +67,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			close(s.token)
 			return
 		}
+		s.refreshToken = r.URL.Query().Get("refresh_token")
 		s.token <- token
 		// We redirect to `/` to print a "successful auth" message and strip
 		// the token out of the URI
@@ -95,6 +98,11 @@ func (s *server) Token() (string, error) {
 		<-s.token
 		return t, nil
 	}
+}
+
+// RefreshToken is called after Token(), so we don't need any blocking here.
+func (s *server) RefreshToken() string {
+	return s.refreshToken
 }
 
 func (s *server) Close() error {


### PR DESCRIPTION
This enables accepting a refresh token (together with an access token) in the http callback server.