### PR TITLE
add `IAM_GROUPS_CREATE` cap to registry push caps

### DIFF
--- a/proto/capabilities/roles.go
+++ b/proto/capabilities/roles.go
@@ -122,6 +122,9 @@ var (
 		Capability_CAP_TAG_CREATE,
 		Capability_CAP_TAG_UPDATE,
 		Capability_CAP_TAG_DELETE,
+
+		// To create nested groups as needed on push.
+		Capability_CAP_IAM_GROUPS_CREATE,
 	}, RegistryPullCaps...))
 
 	RegistryPullTokenCreatorCaps = sortCaps(append([]Capability{


### PR DESCRIPTION
To enable nested repos, users that have `registry.push` will need to be able to create missing groups between the org and the repo.