### PR TITLE
use clog instead of knative.dev/pkg/logging

### DIFF
--- a/auth/file.go
+++ b/auth/file.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/chainguard-dev/clog"
 	"google.golang.org/grpc/credentials"
-	"knative.dev/pkg/logging"
 )
 
 type fileAuth struct {
@@ -38,7 +38,7 @@ func (fa *fileAuth) GetRequestMetadata(ctx context.Context, uri ...string) (map[
 	// expiration before it is refreshed is 2 minutes.  Use 1 minute to give
 	// us wiggle room, but we should have 2 minutes to validate the token.
 	if time.Since(fa.lastUpdated) < time.Minute {
-		logging.FromContext(ctx).Infof("Using cached token, last refreshed %v", fa.lastUpdated)
+		clog.FromContext(ctx).Infof("Using cached token, last refreshed %v", fa.lastUpdated)
 		return map[string]string{
 			"Authorization": string(fa.cache),
 		}, nil
@@ -50,7 +50,7 @@ func (fa *fileAuth) GetRequestMetadata(ctx context.Context, uri ...string) (map[
 	}
 	fa.cache = b
 	fa.lastUpdated = time.Now()
-	logging.FromContext(ctx).Info("Using fresh token.")
+	clog.FromContext(ctx).Info("Using fresh token.")
 	return map[string]string{
 		"Authorization": string(b),
 	}, nil

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -14,15 +14,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/chainguard-dev/clog"
 	"google.golang.org/grpc/credentials"
-	"knative.dev/pkg/logging"
 )
 
 // NewFromFile attempts to create a new credentials.PerRPCCredentials based on the provided file.
 // Returns nil if not found.
 func NewFromFile(ctx context.Context, path string, requireTransportSecurity bool) credentials.PerRPCCredentials {
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		logging.FromContext(ctx).Infof("Using OIDC token from %s to authenticate requests.", path)
+		clog.FromContext(ctx).Infof("Using OIDC token from %s to authenticate requests.", path)
 		return &fileAuth{
 			file:   path,
 			secure: requireTransportSecurity,

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,15 @@
 module chainguard.dev/sdk
 
-go 1.21
+go 1.21.2
+
+toolchain go1.21.5
 
 require (
 	chainguard.dev/go-grpc-kit v0.17.2
 	chainguard.dev/go-oidctest v0.2.0
 	github.com/aws/aws-sdk-go-v2 v1.24.1
 	github.com/bits-and-blooms/bitset v1.13.0
+	github.com/chainguard-dev/clog v1.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.0
 	github.com/coreos/go-oidc/v3 v3.9.0
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4r
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chainguard-dev/clog v1.3.0 h1:L/ey0VNH958YpzQa5OO2e2q+iOENxtLAhqkmgzh03e0=
+github.com/chainguard-dev/clog v1.3.0/go.mod h1:cV516KZWqYc/phZsCNwF36u/KMGS+Gj5Uqeb8Hlp95Y=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudevents/sdk-go/v2 v2.15.0 h1:aKnhLQhyoJXqEECQdOIZnbZ9VupqlidE6hedugDGr+I=
 github.com/cloudevents/sdk-go/v2 v2.15.0/go.mod h1:lL7kSWAE/V8VI4Wh0jbL2v/jvqsm6tjmaQBSvxcv4uE=

--- a/proto/capabilities/capabilities.go
+++ b/proto/capabilities/capabilities.go
@@ -15,12 +15,12 @@ import (
 	"sync"
 
 	"github.com/bits-and-blooms/bitset"
+	"github.com/chainguard-dev/clog"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
-	"knative.dev/pkg/logging"
 )
 
 var (
@@ -84,7 +84,7 @@ func Parse(name string) (Capability, error) {
 			if perror == nil {
 				nameCapabilityMap[scap] = Capability(cap)
 			} else {
-				logging.FromContext(context.Background()).Errorf("Failed to stringify capability %d, error: %v",
+				clog.FromContext(context.Background()).Errorf("Failed to stringify capability %d, error: %v",
 					cap, zap.Error(perror))
 			}
 		}

--- a/proto/platform/advisory/v1/clients.go
+++ b/proto/platform/advisory/v1/clients.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	delegate "chainguard.dev/go-grpc-kit/pkg/options"
+	"github.com/chainguard-dev/clog"
 	"google.golang.org/grpc"
-	"knative.dev/pkg/logging"
 
 	"chainguard.dev/sdk/auth"
 )
@@ -36,7 +36,7 @@ func NewClients(ctx context.Context, addr string, token string) (Clients, error)
 	if cred := auth.NewFromToken(ctx, token, false); cred != nil {
 		opts = append(opts, grpc.WithPerRPCCredentials(cred))
 	} else {
-		logging.FromContext(ctx).Warn("No authentication provided, this may end badly.")
+		clog.FromContext(ctx).Warn("No authentication provided, this may end badly.")
 	}
 
 	var cancel context.CancelFunc

--- a/proto/platform/clients.go
+++ b/proto/platform/clients.go
@@ -19,9 +19,9 @@ import (
 	ping "chainguard.dev/sdk/proto/platform/ping/v1"
 	registry "chainguard.dev/sdk/proto/platform/registry/v1"
 	tenant "chainguard.dev/sdk/proto/platform/tenant/v1"
+	"github.com/chainguard-dev/clog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"knative.dev/pkg/logging"
 )
 
 type userAgentString struct{}
@@ -48,7 +48,7 @@ func NewPlatformClients(ctx context.Context, apiURL string, cred credentials.Per
 	if cred != nil {
 		opts = append(opts, grpc.WithPerRPCCredentials(cred))
 	} else {
-		logging.FromContext(ctx).Warn("No authentication provided, this may end badly.")
+		clog.FromContext(ctx).Warn("No authentication provided, this may end badly.")
 	}
 	if ua := GetUserAgent(ctx); ua != "" {
 		opts = append(opts, grpc.WithUserAgent(ua))
@@ -129,7 +129,7 @@ func NewOIDCClients(ctx context.Context, issuerURL string, cred credentials.PerR
 	if cred != nil {
 		opts = append(opts, grpc.WithPerRPCCredentials(cred))
 	} else {
-		logging.FromContext(ctx).Warn("No authentication provided, this may end badly.")
+		clog.FromContext(ctx).Warn("No authentication provided, this may end badly.")
 	}
 	if ua := GetUserAgent(ctx); ua != "" {
 		opts = append(opts, grpc.WithUserAgent(ua))

--- a/proto/platform/iam/v1/clients.go
+++ b/proto/platform/iam/v1/clients.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	delegate "chainguard.dev/go-grpc-kit/pkg/options"
+	"github.com/chainguard-dev/clog"
 	"google.golang.org/grpc"
-	"knative.dev/pkg/logging"
 
 	"chainguard.dev/sdk/auth"
 	events "chainguard.dev/sdk/proto/platform/events/v1"
@@ -52,7 +52,7 @@ func NewClients(ctx context.Context, iamURL string, token string) (Clients, erro
 	if cred := auth.NewFromToken(ctx, token, false); cred != nil {
 		opts = append(opts, grpc.WithPerRPCCredentials(cred))
 	} else {
-		logging.FromContext(ctx).Warn("No authentication provided, this may end badly.")
+		clog.FromContext(ctx).Warn("No authentication provided, this may end badly.")
 	}
 
 	var cancel context.CancelFunc

--- a/proto/platform/oidc/v1/clients.go
+++ b/proto/platform/oidc/v1/clients.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	delegate "chainguard.dev/go-grpc-kit/pkg/options"
+	"github.com/chainguard-dev/clog"
 	"google.golang.org/grpc"
-	"knative.dev/pkg/logging"
 
 	"chainguard.dev/sdk/auth"
 )
@@ -52,7 +52,7 @@ func NewClients(ctx context.Context, addr string, token string, opts ...ClientOp
 	if cred := auth.NewFromToken(ctx, token, false); cred != nil {
 		rpcOpts = append(rpcOpts, grpc.WithPerRPCCredentials(cred))
 	} else {
-		logging.FromContext(ctx).Warn("No authentication provided, this may end badly.")
+		clog.FromContext(ctx).Warn("No authentication provided, this may end badly.")
 	}
 
 	if conf.userAgent != "" {

--- a/proto/platform/ping/v1/clients.go
+++ b/proto/platform/ping/v1/clients.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	delegate "chainguard.dev/go-grpc-kit/pkg/options"
+	"github.com/chainguard-dev/clog"
 	"google.golang.org/grpc"
-	"knative.dev/pkg/logging"
 
 	"chainguard.dev/sdk/auth"
 )
@@ -36,7 +36,7 @@ func NewClients(ctx context.Context, addr string, token string) (Clients, error)
 	if cred := auth.NewFromToken(ctx, token, false); cred != nil {
 		opts = append(opts, grpc.WithPerRPCCredentials(cred))
 	} else {
-		logging.FromContext(ctx).Warn("No authentication provided, this may end badly.")
+		clog.FromContext(ctx).Warn("No authentication provided, this may end badly.")
 	}
 
 	var cancel context.CancelFunc

--- a/proto/platform/registry/v1/clients.go
+++ b/proto/platform/registry/v1/clients.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	delegate "chainguard.dev/go-grpc-kit/pkg/options"
+	"github.com/chainguard-dev/clog"
 	"google.golang.org/grpc"
-	"knative.dev/pkg/logging"
 
 	"chainguard.dev/sdk/auth"
 )
@@ -36,7 +36,7 @@ func NewClients(ctx context.Context, addr string, token string) (Clients, error)
 	if cred := auth.NewFromToken(ctx, token, false); cred != nil {
 		opts = append(opts, grpc.WithPerRPCCredentials(cred))
 	} else {
-		logging.FromContext(ctx).Warn("No authentication provided, this may end badly.")
+		clog.FromContext(ctx).Warn("No authentication provided, this may end badly.")
 	}
 
 	var cancel context.CancelFunc

--- a/proto/platform/tenant/v1/clients.go
+++ b/proto/platform/tenant/v1/clients.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	delegate "chainguard.dev/go-grpc-kit/pkg/options"
+	"github.com/chainguard-dev/clog"
 	"google.golang.org/grpc"
-	"knative.dev/pkg/logging"
 
 	"chainguard.dev/sdk/auth"
 )
@@ -47,7 +47,7 @@ func NewClients(ctx context.Context, addr string, token string) (Clients, error)
 	if cred := auth.NewFromToken(ctx, token, false); cred != nil {
 		opts = append(opts, grpc.WithPerRPCCredentials(cred))
 	} else {
-		logging.FromContext(ctx).Warn("No authentication provided, this may end badly.")
+		clog.FromContext(ctx).Warn("No authentication provided, this may end badly.")
 	}
 
 	var cancel context.CancelFunc


### PR DESCRIPTION
knative.dev/pkg/apis is still used by `policy`, but otherwise knative.dev/pkg is unused after this.