### PR TITLE
login: wrap error returned from `browser.OpenURL` with type `OpenBrowserError`

### DIFF
--- a/auth/login/login.go
+++ b/auth/login/login.go
@@ -17,6 +17,15 @@ import (
 	"github.com/pkg/browser"
 )
 
+// OpenBrowserError wraps the error returned from browser.OpenURL,
+// since this can take a few different forms depending on the OS.
+type OpenBrowserError struct {
+	err error
+}
+
+func (e *OpenBrowserError) Error() string { return "failed to open browser: " + e.err.Error() }
+func (e *OpenBrowserError) Unwrap() error { return e.err }
+
 func Login(ctx context.Context, opts ...Option) (token string, refreshToken string, err error) {
 	conf, err := newConfigFromOptions(opts...)
 	if err != nil {
@@ -68,7 +77,7 @@ func Login(ctx context.Context, opts ...Option) (token string, refreshToken stri
 	fmt.Fprintf(os.Stderr, "Opening browser to %s\n", u)
 	err = browser.OpenURL(u)
 	if err != nil {
-		return "", "", err
+		return "", "", &OpenBrowserError{err}
 	}
 
 	token, err = s.Token()

--- a/auth/login/login_test.go
+++ b/auth/login/login_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2024 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package login
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestOpenBrowserErrorAs(t *testing.T) {
+	tests := map[string]struct {
+		err  error
+		want bool
+	}{
+		"nil": {
+			err:  nil,
+			want: false,
+		},
+		"success": {
+			err: &OpenBrowserError{
+				errors.New("unit test"),
+			},
+			want: true,
+		},
+		"failure": {
+			err:  errors.New("unit test"),
+			want: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var want *OpenBrowserError
+			got := errors.As(test.err, &want)
+			if got != test.want {
+				t.Errorf("As() expected %t, got %t", test.want, got)
+			}
+			if got {
+				t.Log(want.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
`browser.OpenURL` returns a few different errors, depending on the OS. To make it simplier to determine if an error returned from `login.Login` is related to `browser.OpenURL`, wrap the error returned from the latter with `OpenBrowserError` so clients can act accordingly.