### PR TITLE
cve-dashboard: package-cve events 

### DIFF
--- a/events/cve-dashboard/cve_dashboard.go
+++ b/events/cve-dashboard/cve_dashboard.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2024 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cve_dashboard
+
+import (
+	"chainguard.dev/sdk/civil"
+)
+
+const PackageCVEEventType = "dev.chainguard.cvedashboard.package.cve.v1"
+
+// PackageCVEEvent is an event used to notify either the CVE detection on packages or their resolution
+type PackageCVEEvent struct {
+	// Package name affected by a CVE
+	Package string `json:"package"`
+
+	// Repository of the package
+	Repository string `json:"repository"`
+
+	// List of subpackages affected by a CVE in a package
+	Subpackages []string `json:"subpackages,omitempty"`
+
+	// List of versions affected by a CVE in a package
+	Versions []string `json:"versions"`
+
+	// Vulnerability ID
+	Vulnerability string `json:"vulnerability"`
+
+	// Alias of the Vulnerability
+	Alias []string `json:"alias"`
+
+	// Severity of the vulnerability
+	Severity string `json:"severity"`
+
+	// Component and version affected by the vulnerability
+	Component string `json:"component"`
+
+	// ComponentType indicates the type of affected vulnerability, e.g. gem, go-module, java-archive
+	ComponentType string `json:"componentType"`
+
+	// Images names and digest affected by the vulnerability
+	Images []string `json:"images"`
+
+	// Affected tags by the vulnerability
+	Tags []string `json:"tags"`
+
+	// Remediation Pull Requests associated to a similar CVE in the same package
+	PR []string `json:"pr,omitempty"`
+
+	// Type determines whether the CVE in the Package is a detection or a resolution: detected or resolved.
+	Type string `json:"type"`
+
+	// When holds when the generation of the report occurred.
+	When civil.DateTime `json:"when"`
+
+	// Reason of the resolution of the CVE for the package
+	Reason string `json:"reason,omitempty"`
+
+	// IsEOL defines whether the package is under EOL Grace Period
+	IsEOL bool `json:"is_eol"`
+
+	// IsLatestAPK defines whether the package version matches the latest available in our package repository
+	IsLatestAPK bool `json:"latest_apk"`
+}


### PR DESCRIPTION
This event collects data about detected CVEs that our cve-dashboard has previously received and inspected to open/close CVE issues affecting pairs <package/CVE-ID>.

Initially I thought about creating two types of Events one for detection and another when resolving a CVE for a package. However I didn't see much of a different between the list of involved attr per event type. 

I've added fields such as Reason (to add any details when closing an issue) or Type to filter them by `detection` or `resolution`.

This event would be used by many other future services which will be decomposed on separate services but are now part of the cve-dashboard service.